### PR TITLE
Allow text to be kept upright

### DIFF
--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -13,11 +13,20 @@ class Context {
   final VectorTile tile;
   final double zoomScaleFactor;
   final double zoom;
+  final double rotation;
   final Rect tileSpace;
   final Rect tileClip;
   late final LabelSpace labelSpace;
 
-  Context(this.logger, this.canvas, this.featureRenderer, this.tile,
-      this.zoomScaleFactor, this.zoom, this.tileSpace, this.tileClip)
-      : labelSpace = LabelSpace(tileSpace);
+  Context(
+    this.logger,
+    this.canvas,
+    this.featureRenderer,
+    this.tile,
+    this.zoomScaleFactor,
+    this.zoom,
+    this.tileSpace,
+    this.tileClip,
+    this.rotation,
+  ) : labelSpace = LabelSpace(tileSpace);
 }

--- a/lib/src/features/symbol_line_renderer.dart
+++ b/lib/src/features/symbol_line_renderer.dart
@@ -54,7 +54,14 @@ class SymbolLineRenderer extends FeatureRenderer {
         final metrics = path.computeMetrics().toList();
         if (metrics.length > 0) {
           final abbreviated = TextAbbreviator().abbreviate(text);
-          final renderer = TextRenderer(context, style, abbreviated, feature);
+          final renderer = TextRenderer(
+            context,
+            style,
+            abbreviated,
+            feature,
+            layer,
+            textLayout.keepUpright,
+          );
           final renderBox = _findMiddleMetric(context, metrics, renderer);
           if (renderBox != null) {
             final tangent = renderBox.tangent;

--- a/lib/src/features/symbol_point_renderer.dart
+++ b/lib/src/features/symbol_point_renderer.dart
@@ -35,7 +35,14 @@ class SymbolPointRenderer extends FeatureRenderer {
       final text = textLayout.text.evaluate(toArgsMap(context, feature));
       if (text != null) {
         final abbreviated = TextAbbreviator().abbreviate(text);
-        final textRenderer = TextRenderer(context, style, abbreviated, feature);
+        final textRenderer = TextRenderer(
+          context,
+          style,
+          abbreviated,
+          feature,
+          layer,
+          textLayout.keepUpright,
+        );
         points.forEach((point) {
           points.forEach((point) {
             if (point.length < 2) {

--- a/lib/src/renderer.dart
+++ b/lib/src/renderer.dart
@@ -25,15 +25,21 @@ class Renderer {
   ///        no scaling is being applied.
   /// [zoom] the current zoom level, which is used to filter theme layers
   ///        via `minzoom` and `maxzoom`. Value must be >= 0 and <= 24
-  void render(Canvas canvas, VectorTile tile,
-      {Rect? clip, required double zoomScaleFactor, required double zoom}) {
+  void render(
+    Canvas canvas,
+    VectorTile tile, {
+    Rect? clip,
+    required double zoomScaleFactor,
+    required double zoom,
+    double rotation = 0.0,
+  }) {
     final tileSpace =
         Rect.fromLTWH(0, 0, tileSize.toDouble(), tileSize.toDouble());
     canvas.save();
     canvas.clipRect(tileSpace);
     final tileClip = clip ?? tileSpace;
     final context = Context(logger, canvas, featureRenderer, tile,
-        zoomScaleFactor, zoom, tileSpace, tileClip);
+        zoomScaleFactor, zoom, tileSpace, tileClip, rotation);
     final effectiveTheme = theme.atZoom(zoom);
     effectiveTheme.layers.forEach((themeLayer) {
       logger.log(() => 'rendering theme layer ${themeLayer.id}');

--- a/lib/src/themes/style.dart
+++ b/lib/src/themes/style.dart
@@ -55,6 +55,7 @@ class TextLayout {
   final LayoutPlacement placement;
   final Expression<String>? anchor;
   final Expression<String> text;
+  final Expression<bool> keepUpright;
   final Expression<double> textSize;
   final Expression<double>? textLetterSpacing;
   final FontStyle? fontStyle;
@@ -65,6 +66,7 @@ class TextLayout {
       {required this.placement,
       required this.anchor,
       required this.text,
+      required this.keepUpright,
       required this.textSize,
       required this.textLetterSpacing,
       required this.fontFamily,

--- a/lib/src/themes/theme_reader.dart
+++ b/lib/src/themes/theme_reader.dart
@@ -126,6 +126,8 @@ class ThemeReader {
         LayoutPlacement.fromName(layout?['symbol-placement'] as String?);
     final anchor = parse<String>(layout?['text-anchor']);
     final textFunction = parse<String>(layout?['text-field'])!;
+    final keepUpright =
+        parse<bool>(layout?['text-keep-upright']) ?? ValueExpression(true);
 
     final font = layout?['text-font'];
     String? fontFamily;
@@ -147,6 +149,7 @@ class ThemeReader {
       placement: placement,
       anchor: anchor,
       text: textFunction,
+      keepUpright: keepUpright,
       textSize: textSize,
       textLetterSpacing: textLetterSpacing,
       fontFamily: fontFamily,

--- a/test/src/expressions/case.dart
+++ b/test/src/expressions/case.dart
@@ -1,0 +1,31 @@
+import 'package:test/test.dart';
+import 'package:vector_tile_renderer/src/expressions/argument_expression.dart';
+import 'package:vector_tile_renderer/src/expressions/case_expression.dart';
+import 'package:vector_tile_renderer/src/expressions/value_expression.dart';
+
+import 'helpers.dart';
+
+void main() {
+  test('case expression evaluates value of first true expression', () {
+    final expression = CaseExpression<String>(
+      [
+        Case<String>(ValueExpression(false), ValueExpression('false')),
+        Case<String>(
+            ArgumentExpression('true-value'), ValueExpression('result')),
+        Case<String>(ValueExpression(true), ValueExpression('wrong result')),
+      ],
+      ValueExpression('fallback'),
+    );
+
+    expectEvaluated(expression, 'result', {'true-value': true});
+  });
+
+  test('case expression evaluates fallback in case of no true expression', () {
+    final expression = CaseExpression<String>(
+      [Case<String>(ValueExpression(false), ValueExpression('false'))],
+      ValueExpression('fallback'),
+    );
+
+    expectEvaluated(expression, 'fallback');
+  });
+}

--- a/test/src/expressions/coalesce.dart
+++ b/test/src/expressions/coalesce.dart
@@ -1,0 +1,26 @@
+import 'package:test/test.dart';
+import 'package:vector_tile_renderer/src/expressions/argument_expression.dart';
+import 'package:vector_tile_renderer/src/expressions/coalesce_expression.dart';
+import 'package:vector_tile_renderer/src/expressions/value_expression.dart';
+
+import 'helpers.dart';
+
+void main() {
+  test('coalesce returns the first non-null value', () {
+    final expression = CoalesceExpression<String>([
+      ValueExpression(null),
+      ArgumentExpression('doesnt-exist'),
+      ArgumentExpression('result'),
+      ArgumentExpression('also-exists')
+    ]);
+
+    final args = {'result': 'result', 'also-exists': 'wrong'};
+
+    expectEvaluated(expression, 'result', args);
+  });
+
+  test('coalesce returns null if no expression is non-null', () {
+    final expression = CoalesceExpression<String>([ValueExpression(null)]);
+    expectEvaluated(expression, null);
+  });
+}

--- a/test/src/expressions/helpers.dart
+++ b/test/src/expressions/helpers.dart
@@ -1,0 +1,8 @@
+import 'package:test/test.dart';
+import 'package:vector_tile_renderer/src/expressions/expression.dart';
+
+void expectEvaluated<T>(Expression<T> actual, dynamic expected,
+    [Map<String, dynamic> args = const {}]) {
+  final evaluated = actual.evaluate(args);
+  expect(evaluated, expected);
+}

--- a/test/src/expressions/interpolations/cubic_bezier.dart
+++ b/test/src/expressions/interpolations/cubic_bezier.dart
@@ -1,0 +1,34 @@
+import 'package:test/test.dart';
+import 'package:vector_math/vector_math.dart';
+import 'package:vector_tile_renderer/src/expressions/argument_expression.dart';
+import 'package:vector_tile_renderer/src/expressions/interpolate/cubic_bezier_interpolation_expression.dart';
+import 'package:vector_tile_renderer/src/expressions/value_expression.dart';
+import 'package:vector_tile_renderer/src/themes/theme_function_model.dart';
+
+import '../helpers.dart';
+
+void main() {
+  final expression = CubicBezierInterpolationExpression<double>(
+    Vector2(0.5, 0),
+    Vector2(1, 1),
+    ArgumentExpression<double>('zoom'),
+    [
+      FunctionStop<double>(ValueExpression(0), ValueExpression(0)),
+      FunctionStop<double>(ValueExpression(100), ValueExpression(10)),
+    ],
+  );
+
+  test('Linear interpolation uses values based on stops', () {
+    const delta = 0.00001;
+
+    expectEvaluated(expression, 0, {'zoom': 0});
+    expectEvaluated(expression, closeTo(1.27778, delta), {'zoom': 1});
+    expectEvaluated(expression, closeTo(81.98363, delta), {'zoom': 9});
+    expectEvaluated(expression, 100, {'zoom': 10});
+  });
+
+  test('Linear interpolation uses last values when outside of bounds', () {
+    expectEvaluated(expression, 0, {'zoom': -1});
+    expectEvaluated(expression, 100, {'zoom': 100});
+  });
+}

--- a/test/src/expressions/interpolations/exponential.dart
+++ b/test/src/expressions/interpolations/exponential.dart
@@ -1,0 +1,32 @@
+import 'package:test/test.dart';
+import 'package:vector_tile_renderer/src/expressions/argument_expression.dart';
+import 'package:vector_tile_renderer/src/expressions/interpolate/exponential_interpolation_expression.dart';
+import 'package:vector_tile_renderer/src/expressions/value_expression.dart';
+import 'package:vector_tile_renderer/src/themes/theme_function_model.dart';
+
+import '../helpers.dart';
+
+void main() {
+  final expression = ExponentialInterpolationExpression<double>(
+    2,
+    ArgumentExpression('zoom'),
+    [
+      FunctionStop<double>(ValueExpression(0), ValueExpression(0)),
+      FunctionStop<double>(ValueExpression(10), ValueExpression(100)),
+    ],
+  );
+
+  test('Exponential interpolation uses values based on stops', () {
+    const delta = 0.00001;
+
+    expectEvaluated(expression, 0, {'zoom': 0});
+    expectEvaluated(expression, closeTo(0.09775, delta), {'zoom': 1});
+    expectEvaluated(expression, closeTo(49.95112, delta), {'zoom': 9});
+    expectEvaluated(expression, 100, {'zoom': 10});
+  });
+
+  test('Exponential interpolation uses last values when outside of bounds', () {
+    expectEvaluated(expression, 0, {'zoom': -1});
+    expectEvaluated(expression, 100, {'zoom': 100});
+  });
+}

--- a/test/src/expressions/interpolations/linear.dart
+++ b/test/src/expressions/interpolations/linear.dart
@@ -1,0 +1,28 @@
+import 'package:test/test.dart';
+import 'package:vector_tile_renderer/src/expressions/argument_expression.dart';
+import 'package:vector_tile_renderer/src/expressions/interpolate/linear_interpolation_expression.dart';
+import 'package:vector_tile_renderer/src/expressions/value_expression.dart';
+import 'package:vector_tile_renderer/src/themes/theme_function_model.dart';
+
+import '../helpers.dart';
+
+void main() {
+  final expression = LinearInterpolationExpression<double>(
+    ArgumentExpression('zoom'),
+    [
+      FunctionStop<double>(ValueExpression(0), ValueExpression(0)),
+      FunctionStop<double>(ValueExpression(10), ValueExpression(100)),
+    ],
+  );
+
+  test('Linear interpolation uses values based on stops', () {
+    expectEvaluated(expression, 0, {'zoom': 0});
+    expectEvaluated(expression, 50, {'zoom': 5});
+    expectEvaluated(expression, 100, {'zoom': 10});
+  });
+
+  test('Linear interpolation uses last values when outside of bounds', () {
+    expectEvaluated(expression, 0, {'zoom': -1});
+    expectEvaluated(expression, 100, {'zoom': 100});
+  });
+}

--- a/test/src/expressions/match.dart
+++ b/test/src/expressions/match.dart
@@ -1,0 +1,45 @@
+import 'package:test/test.dart';
+import 'package:vector_tile_renderer/src/expressions/match_expression.dart';
+import 'package:vector_tile_renderer/src/expressions/value_expression.dart';
+
+import 'helpers.dart';
+
+void main() {
+  test('match expression evaluates first output matching input', () {
+    final expression = MatchExpression<String, String>(
+      ValueExpression('input'),
+      [
+        Match<String, String>(
+          ValueExpression('not-input'),
+          ValueExpression('not-input'),
+        ),
+        Match<String, String>(
+          ValueExpression('input'),
+          ValueExpression('result'),
+        ),
+        Match<String, String>(
+          ValueExpression('input'),
+          ValueExpression('not-result'),
+        ),
+      ],
+      ValueExpression('fallback'),
+    );
+
+    expectEvaluated(expression, 'result');
+  });
+
+  test('match expression evaluates fallback if no match matches', () {
+    final expression = MatchExpression<String, String>(
+      ValueExpression('input'),
+      [
+        Match<String, String>(
+          ValueExpression('not-input'),
+          ValueExpression('not-input'),
+        ),
+      ],
+      ValueExpression('fallback'),
+    );
+
+    expectEvaluated(expression, 'fallback');
+  });
+}

--- a/test/src/expressions/step.dart
+++ b/test/src/expressions/step.dart
@@ -1,0 +1,27 @@
+import 'package:test/test.dart';
+import 'package:vector_tile_renderer/src/expressions/argument_expression.dart';
+import 'package:vector_tile_renderer/src/expressions/step_expression.dart';
+import 'package:vector_tile_renderer/src/expressions/value_expression.dart';
+
+import 'helpers.dart';
+
+void main() {
+  test('step expression picks values based on steps', () {
+    final expression = StepExpression<String>(
+      ArgumentExpression<double>('zoom'),
+      ValueExpression('base'),
+      [
+        Step<String>(1, ValueExpression('1')),
+        Step<String>(3, ValueExpression('3')),
+        Step<String>(7, ValueExpression('7')),
+        Step<String>(20, ValueExpression('20')),
+      ],
+    );
+
+    expectEvaluated(expression, 'base', {'zoom': 0});
+    expectEvaluated(expression, '1', {'zoom': 1});
+    expectEvaluated(expression, '1', {'zoom': 2.99999});
+    expectEvaluated(expression, '3', {'zoom': 3});
+    expectEvaluated(expression, '20', {'zoom': 200});
+  });
+}

--- a/test/src/themes/color_parser_test.dart
+++ b/test/src/themes/color_parser_test.dart
@@ -1,36 +1,36 @@
 import 'package:test/test.dart';
-import 'package:vector_tile_renderer/src/themes/color_parser.dart';
+import 'package:vector_tile_renderer/src/parsers/color.dart';
 
 void main() {
   test('parses a hex RGB color', () {
-    final color = ColorParser.toColor('#90d86c');
+    final color = ColorParser().parseString('#90d86c');
     expect(color, isNotNull);
-    expect(color!.alpha, 0xff);
+    expect(color.alpha, 0xff);
     expect(color.red, 0x90);
     expect(color.green, 0xd8);
     expect(color.blue, 0x6c);
   });
 
   test('parses an RGB color', () {
-    final color = ColorParser.toColor('rgb(239, 238,12)');
+    final color = ColorParser().parseString('rgb(239, 238,12)');
     expect(color, isNotNull);
-    expect(color!.alpha, 0xff);
+    expect(color.alpha, 0xff);
     expect(color.red, 239);
     expect(color.green, 238);
     expect(color.blue, 12);
   });
   test('parses an hsl color', () {
-    final color = ColorParser.toColor('hsl(248, 7%, 66%)');
+    final color = ColorParser().parseString('hsl(248, 7%, 66%)');
     expect(color, isNotNull);
-    expect(color!.alpha, 0xff);
+    expect(color.alpha, 0xff);
     expect(color.red, 0xA4);
     expect(color.green, 0xA2);
     expect(color.blue, 0xAE);
   });
   test('parses an hsla color', () {
-    final color = ColorParser.toColor('hsla(96, 40%, 49%, 0.36)');
+    final color = ColorParser().parseString('hsla(96, 40%, 49%, 0.36)');
     expect(color, isNotNull);
-    expect(color!.alpha, 92);
+    expect(color.alpha, 92);
     expect(color.red, 0x73);
     expect(color.green, 0xAF);
     expect(color.blue, 0x4B);

--- a/test/src/themes/theme_function_model_test.dart
+++ b/test/src/themes/theme_function_model_test.dart
@@ -27,7 +27,7 @@ void main() {
     };
     final model = DoubleFunctionModelFactory().create(definition);
     expect(model, isNotNull);
-    expect(model!.base, 1.4);
+    expect(model!.base!.evaluate({}), 1.4);
     expect(model.stops, hasLength(2));
     expect(model.stops[0].zoom, 8);
     expect(model.stops[0].value, 1);

--- a/test/src/themes/theme_function_test.dart
+++ b/test/src/themes/theme_function_test.dart
@@ -1,31 +1,53 @@
 import 'package:test/test.dart';
+import 'package:vector_tile_renderer/src/expressions/value_expression.dart';
 import 'package:vector_tile_renderer/src/themes/theme_function.dart';
 import 'package:vector_tile_renderer/src/themes/theme_function_model.dart';
 
 void main() {
-  final definition = FunctionModel<double>(
-      1.2, [FunctionStop<double>(14, 0.5), FunctionStop<double>(20, 10)]);
+  ValueExpression<double> v(double value) => ValueExpression(value);
+  Map<String, dynamic> withZoom(double zoom) => {'zoom': zoom};
+
+  final definition = FunctionModel<double>(v(1.2), [
+    FunctionStop<double>(v(14), v(1.09)),
+    FunctionStop<double>(v(20), v(6.19)),
+  ]);
 
   final function = DoubleThemeFunction();
   final epsilon = 0.006;
   test('provides null for zoom values less than the lowest stop', () {
-    expect(function.exponential(definition, 12), isNull);
-    expect(function.exponential(definition, 13), isNull);
-    expect(function.exponential(definition, 13.9), isNull);
+    expect(function.exponential(definition, withZoom(12)), isNull);
+    expect(function.exponential(definition, withZoom(13)), isNull);
+    expect(function.exponential(definition, withZoom(13.9)), isNull);
   });
 
   test('produces an exponent based on stops', () {
-    expect(function.exponential(definition, 14), closeTo(1.09, epsilon));
-    expect(function.exponential(definition, 20), closeTo(6.19, epsilon));
+    expect(
+      function.exponential(definition, withZoom(14)),
+      closeTo(1.09, epsilon),
+    );
+
+    expect(
+      function.exponential(definition, withZoom(20)),
+      closeTo(6.19, epsilon),
+    );
   });
+
   test('produces an exponent with zoom greater than top stop', () {
-    expect(function.exponential(definition, 100), closeTo(6.19, epsilon));
+    expect(
+      function.exponential(definition, withZoom(100)),
+      closeTo(6.19, epsilon),
+    );
   });
-  test('produces null with zoom less than bottom stop', () {
-    expect(function.exponential(definition, 0), isNull);
-  });
+
   test('produces an exponent with zoom between stops', () {
-    expect(function.exponential(definition, 15), closeTo(1.46, epsilon));
-    expect(function.exponential(definition, 19), closeTo(4.64, epsilon));
+    expect(
+      function.exponential(definition, withZoom(15)),
+      closeTo(1.46, epsilon),
+    );
+
+    expect(
+      function.exponential(definition, withZoom(19)),
+      closeTo(4.64, epsilon),
+    );
   });
 }


### PR DESCRIPTION
This PR expands on the expression system built in https://github.com/greensopinion/dart-vector-tile-renderer/pull/2/ allowing evaluation of the `text-keep-upright` properties of a theme and using the context's rotation to make sure the text is kept "upright".

This PR won't be merged here but aims to be merged into upstream's main branch once the above mentioned pull request has been merged.